### PR TITLE
Add class to handle message formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SecMes [WIP]
+# SecMes
 In an effort to both brush up on C++, and learn more about sockets and
 encryption libraries, I decided to write a fairly simple p2p messaging app. This
 repo is the proving ground for that effort.

--- a/src/net/Message.cpp
+++ b/src/net/Message.cpp
@@ -1,0 +1,76 @@
+#include <cstring>
+#include "net/Message.h"
+
+std::hash<std::string> hash;
+
+Logger* Message::logger = Logger::getLogger();
+
+void Message::log(std::string msg) {
+    logger->log("MessageHandler: "+msg);
+}
+
+std::string Message::pack(std::string msg) {
+    size_t packedMsgLen = msg.size() + (2 * sizeof(size_t));
+    size_t msgHash      = hash(msg);
+    char*  newMsgBuff   = new char[packedMsgLen]();
+
+    int offset = 0;
+    memcpy(newMsgBuff,        &packedMsgLen, sizeof(size_t));
+    offset += sizeof(size_t);
+    memcpy(newMsgBuff+offset, msg.c_str(),   msg.size());
+    offset += msg.size();
+    memcpy(newMsgBuff+offset, &msgHash,      sizeof(size_t));
+
+    std::string retVal(newMsgBuff, packedMsgLen);
+    delete newMsgBuff;
+
+    return retVal;
+}
+
+std::string Message::unpack(std::string msg) {
+    size_t packedMsgLen;
+    size_t unpackedMsgLen = msg.size() - (2 * sizeof(size_t));
+    size_t msgHash;
+
+    int offset = 0;
+    memcpy(&packedMsgLen, msg.c_str(), sizeof(size_t));
+    offset += sizeof(size_t);
+    if( msg.size() == packedMsgLen ) {
+        std::string unpackedMsg(msg.c_str()+offset, unpackedMsgLen);
+        offset += unpackedMsgLen;
+        memcpy(&msgHash, msg.c_str()+offset, sizeof(size_t));
+        if( msgHash == hash(unpackedMsg))
+            return unpackedMsg;
+        else
+            log("Message hash did not match message!");
+    }
+    
+    return std::string();
+}
+
+std::list<std::string> Message::unpackBuffer(char* buffer, size_t len) {
+    std::list<std::string> retList;
+
+    int   bytesToRead = len;
+    int   offset      = 0;
+
+    do {
+        buffer += offset;
+        size_t msgSize;
+        memcpy(&msgSize, buffer, sizeof(size_t));
+
+        if ( msgSize > (bytesToRead-offset) ) {
+            log("Invalid message length! Dumping buffer.");
+            break;
+        }
+
+        std::string msg(unpack(std::string(buffer, msgSize)));
+        if( msg != "" )
+            retList.push_back(msg);
+
+        offset  += msgSize;
+    } while ( offset < bytesToRead );
+
+    return retList;
+}
+

--- a/src/net/Message.h
+++ b/src/net/Message.h
@@ -1,0 +1,21 @@
+#ifndef MESSAGE_H
+#define MESSAGE_H
+
+#include <list>
+#include <string>
+
+#include "log/Logger.h"
+
+class Message {
+    public:
+        static std::string pack(std::string msg);
+        static std::string unpack(std::string msg);
+        static std::list<std::string> unpackBuffer(char*, size_t);
+
+    private:
+        static Logger* logger;
+
+        static void log(std::string);
+};
+
+#endif

--- a/src/net/NetEngine.h
+++ b/src/net/NetEngine.h
@@ -5,11 +5,6 @@
 
 class NetEngine {
     public:
-        /* Note to the Implementor:
-         *  You MUST NOT block infinitely in getMsg().I would suggest not
-         *  waiting for message for longer than 1-2 seconds. If no message is
-         *  received, return "". 
-         */
         virtual bool        hasPendingMsg() = 0;
         virtual std::string getMsg() = 0;
         virtual int         sendMsg(std::string) = 0;

--- a/src/net/UnixSocketNetEngine.h
+++ b/src/net/UnixSocketNetEngine.h
@@ -41,7 +41,6 @@ class UnixSocketNetEngine: public NetEngine {
         void        rcvLoop();
         void        rcvConnection();
         void        rcvMsg();
-        void        processMsgs(char*, size_t);
 
         fd_set      mListenFDs;
         int         mListenMax;


### PR DESCRIPTION
Previously, I put code to handle formatting messages in the
UnixSocketNetEngine. This commit moves that code out into its own class,
where it can be reused by future implementations of NetEngines. This
change also uses a hash to verify the message contents, as opposed to
fixed bit pattern as before.